### PR TITLE
Added support for virtual fields in ListViews

### DIFF
--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -306,10 +306,9 @@ class ListView(View, base.ListView):
                 item = [get_attribute(obj, 'pk')]
                 for field_name in self.fields:
                     if isinstance(field_name, tuple):
-                        if hasattr(self, field_name[0]):
-                            # Call method for virtual field and return row instance
+                        try:
                             value = getattr(self, field_name[0])(obj)
-                        else:
+                        except AttributeError:
                             value = find_attribute(obj, field_name[0])
                     else:
                         try:
@@ -321,10 +320,9 @@ class ListView(View, base.ListView):
                             value = find_attribute(obj, parent_objs + '__' +
                                                    method_name)()
                         except AttributeError:
-                            if hasattr(self, field_name):
-                                # Call method for virtual field and return row instance
+                            try:
                                 value = getattr(self, field_name)(obj)
-                            else:
+                            except AttributeError:
                                 value = find_attribute(obj, field_name)
 
                     item.append(value)

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -306,7 +306,11 @@ class ListView(View, base.ListView):
                 item = [get_attribute(obj, 'pk')]
                 for field_name in self.fields:
                     if isinstance(field_name, tuple):
-                        value = find_attribute(obj, field_name[0])
+                        if hasattr(self, field_name):
+                            # Call method for virtual field and return row instance
+                            value = getattr(self, field_name[0])(obj)
+                        else:
+                            value = find_attribute(obj, field_name[0])
                     else:
                         try:
                             # Get the choice display value
@@ -317,7 +321,11 @@ class ListView(View, base.ListView):
                             value = find_attribute(obj, parent_objs + '__' +
                                                    method_name)()
                         except AttributeError:
-                            value = find_attribute(obj, field_name)
+                            if hasattr(self, field_name):
+                                # Call method for virtual field and return row instance
+                                value = getattr(self, field_name)(obj)
+                            else:
+                                value = find_attribute(obj, field_name)
 
                     item.append(value)
                 items.append(item)

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -306,7 +306,7 @@ class ListView(View, base.ListView):
                 item = [get_attribute(obj, 'pk')]
                 for field_name in self.fields:
                     if isinstance(field_name, tuple):
-                        if hasattr(self, field_name):
+                        if hasattr(self, field_name[0]):
                             # Call method for virtual field and return row instance
                             value = getattr(self, field_name[0])(obj)
                         else:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -147,6 +147,22 @@ Accessing fields from related objects is possible by using a double underscore
 notation, for example if a model `book` has a foreign key to a model author
 with a field name, `author__name` will display the field.
 
+It's also possible to add virtual fields. See virtual fields for more info.
+
+### `virtual fields`
+
+Via the fields property, it's possible to add virtual fields. So you can
+extend the views with custom fields. A virtual field does need an
+accompanying method. That method receives a row_instance, so you can
+manipulate row data there.
+
+Example:
+class MyListView(arctic.ListView):
+    fields = (model_field1, model_field2, not_a_model_field)
+
+    def not_a_model_field(row_instance):
+        return '<b>' + row_instance.model_field3 + '</b>'
+
 ### `search_fields`
 
 list of fields that are to be searched.

--- a/example/articles/views.py
+++ b/example/articles/views.py
@@ -22,7 +22,7 @@ class DashboardView(TemplateView):
 class ArticleListView(ListView):
     paginate_by = 2
     model = Article
-    fields = ['title', 'description', 'published', 'category']
+    fields = ['title', 'description', 'published', 'category', 'virtual_field']
     ordering_fields = ['title', 'description', 'published']
     search_fields = ['title']
     breadcrumbs = (('Home', 'index'), ('Article List', None))
@@ -40,6 +40,9 @@ class ArticleListView(ListView):
         (_('Create Article'), 'articles:create', 'fa-plus'),
     ]
     required_permission = "articles_view"
+
+    def virtual_field(self, row):
+        return 'Virtual Field: ' + row.title
 
 
 class ArticleUpdateView(UpdateView):


### PR DESCRIPTION
It's now possible to add virtual fields in the fields-attribute of
ListView classes. When a virtual field is added to fields, Arctic
will look for an accompanying method (with the same name as the
virtual field) to return customized data.

Example:
class MyListView(arctic.ListView):
    fields = (model_field1, model_field2, not_a_model_field)

    def not_a_model_field(row_instance):
        return '<b>' + row_instance.model_field3 + '</b>'