### PR TITLE
Add docker/docker-compose support for example project

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -147,3 +147,17 @@ also present:
 
 Within the Arctic project there's an `example` project with a more extensive 
 usage of Arctic's features.
+
+The example project has Docker/Docker Compose support (see <https://docs.docker.com/compose/install/> 
+for installation.
+
+To build execute the example Docker image, run:
+ 
+        $ cd example/
+        $ docker-compose up
+        
+The Docker image will be built and example project should be running on <http://localhost:8000/>.
+A demo fixture is loaded automatically. Default login is:
+ 
+        User: admin
+        Password: admin

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for Arctic example project
+
+FROM python:3.5
+
+ENV PYTHONUNBUFFERED 1
+WORKDIR /code
+
+RUN mkdir -p /code
+ADD ./requirements /code/requirements
+RUN pip install -r /code/requirements/requirements.txt
+
+ADD . /code/
+
+RUN python manage.py migrate
+RUN python manage.py loaddata fixtures/demo_data.json
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: "2"
+services:
+  web:
+    build: "."
+    ports:
+      - "8000:8000"
+    volumes:
+      - ".:/code"

--- a/example/fixtures/demo_data.json
+++ b/example/fixtures/demo_data.json
@@ -1,0 +1,20 @@
+[
+{
+  "model": "auth.user",
+  "pk": 1,
+  "fields": {
+    "password": "pbkdf2_sha256$24000$7hRp8bfwAetl$sDL/oZ5g2BkoZ8ngKjHeHa0OhBXO/kW4vrHBu88CA5A=",
+    "last_login": null,
+    "is_superuser": true,
+    "username": "admin",
+    "first_name": "",
+    "last_name": "",
+    "email": "admin@localhost",
+    "is_staff": true,
+    "is_active": true,
+    "date_joined": "2016-10-10T16:51:56.202Z",
+    "groups": [],
+    "user_permissions": []
+  }
+}
+]

--- a/example/requirements/requirements.txt
+++ b/example/requirements/requirements.txt
@@ -1,0 +1,1 @@
+django-arctic==0.9.2


### PR DESCRIPTION
Added docker/docker-compose support for running example project with docker/docker-compose. An advantage is to allow adopters/evaluators to easily run the example project without going through the Python specific development environment setup.
