### PR TITLE
Fixed colliding attribute names for virtual_fields. 

### DIFF
--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -312,7 +312,8 @@ class ListView(View, base.ListView):
                 for field_name in self.fields:
                     if isinstance(field_name, tuple):
                         try:
-                            virtual_field_name = "get_field_{}".format(field_name[0])
+                            virtual_field_name = "get_field_{}".\
+                                format(field_name[0])
                             value = getattr(self, virtual_field_name)(obj)
                         except AttributeError:
                             value = find_attribute(obj, field_name[0])
@@ -327,7 +328,8 @@ class ListView(View, base.ListView):
                                                    method_name)()
                         except AttributeError:
                             try:
-                                virtual_field_name = "get_field_{}".format(field_name)
+                                virtual_field_name = "get_field_{}".\
+                                    format(field_name)
                                 value = getattr(self, virtual_field_name)(obj)
                             except AttributeError:
                                 value = find_attribute(obj, field_name)

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -312,7 +312,8 @@ class ListView(View, base.ListView):
                 for field_name in self.fields:
                     if isinstance(field_name, tuple):
                         try:
-                            value = getattr(self, field_name[0])(obj)
+                            virtual_field_name = "get_field_{}".format(field_name[0])
+                            value = getattr(self, virtual_field_name)(obj)
                         except AttributeError:
                             value = find_attribute(obj, field_name[0])
                     else:
@@ -326,7 +327,8 @@ class ListView(View, base.ListView):
                                                    method_name)()
                         except AttributeError:
                             try:
-                                value = getattr(self, field_name)(obj)
+                                virtual_field_name = "get_field_{}".format(field_name)
+                                value = getattr(self, virtual_field_name)(obj)
                             except AttributeError:
                                 value = find_attribute(obj, field_name)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -153,14 +153,14 @@ It's also possible to add virtual fields. See virtual fields for more info.
 
 Via the fields property, it's possible to add virtual fields. So you can
 extend the views with custom fields. A virtual field does need an
-accompanying method. That method receives a row_instance, so you can
-manipulate row data there.
+accompanying method prefixed with "get_field_". That method receives a
+row_instance, so you can manipulate row data there.
 
 Example:
 class MyListView(arctic.ListView):
     fields = (model_field1, model_field2, not_a_model_field)
 
-    def not_a_model_field(row_instance):
+    def get_field_not_a_model_field(row_instance):
         return '<b>' + row_instance.model_field3 + '</b>'
 
 ### `search_fields`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,3 @@ def get_form(form):
             return {field.name: field
                     for field in form}
     return _get_form
-
-
-def request(uri):
-    factory = RequestFactory()
-    return factory.get(uri)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from django.test.client import RequestFactory
 
 from example.articles.models import Article, Category
 from example.articles.forms import ArticleForm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from django.test.client import RequestFactory
 
 from example.articles.models import Article, Category
 from example.articles.forms import ArticleForm
@@ -7,7 +8,7 @@ from example.articles.forms import ArticleForm
 @pytest.fixture
 def category():
     category = Category()
-    category.name = 'name'
+    category.name = 'name1'
 
     return category
 
@@ -15,11 +16,11 @@ def category():
 @pytest.fixture
 def article():
     article = Article()
-    article.title = 'title'
-    article.description = 'description'
-    article.updated_at = 'updated_at'
+    article.title = 'title1'
+    article.description = 'description1'
+    article.updated_at = 'updated_at1'
     article.category = category()
-    article.published = 'published'
+    article.published = 'published1'
 
     return article
 
@@ -45,3 +46,8 @@ def get_form(form):
             return {field.name: field
                     for field in form}
     return _get_form
+
+
+def request(uri):
+    factory = RequestFactory()
+    return factory.get(uri)

--- a/tests/test_virtual_fields.py
+++ b/tests/test_virtual_fields.py
@@ -1,7 +1,7 @@
 import pytest
 
 from arctic.generics import ListView
-from .conftest import article, request
+from .conftest import article
 
 
 @pytest.fixture
@@ -16,12 +16,14 @@ def virtual_fields_example_1():
 
 
 @pytest.mark.django_db
-def test_virtual_fields_example_1(virtual_fields_example_1):
-    with pytest.raises(AttributeError):
-        self = virtual_fields_example_1
-        self.request = request('/articles/')
-        objects = self.get_object_list()
-        self.get_list_items([objects])
+def test_virtual_fields_example_1(article, virtual_fields_example_1):
+    list_view = virtual_fields_example_1
+
+    with pytest.raises(AttributeError) as excinfo:
+        list_view.get_list_items([article])
+
+    message = "'Article' object has no attribute 'content_type'"
+    assert str(excinfo.value) == message
 
 
 @pytest.fixture
@@ -39,11 +41,9 @@ def virtual_fields_example_2():
 
 
 @pytest.mark.django_db
-def test_virtual_fields_example_2(virtual_fields_example_2):
-    self = virtual_fields_example_2
-    self.request = request('/articles/')
-    objects = self.get_object_list()
-    res = self.get_list_items([objects])
+def test_virtual_fields_example_2(article, virtual_fields_example_2):
+    list_view = virtual_fields_example_2
+    res = list_view.get_list_items([article])
 
     assert res[0][0] is None
     assert res[0][1] == 'title1'
@@ -64,9 +64,11 @@ def virtual_fields_example_3():
 
 
 @pytest.mark.django_db
-def test_virtual_fields_example_3(virtual_fields_example_3):
-    with pytest.raises(AttributeError):
-        self = virtual_fields_example_3
-        self.request = request('/articles/')
-        objects = self.get_object_list()
-        self.get_list_items([objects])
+def test_virtual_fields_example_3(article, virtual_fields_example_3):
+    list_view = virtual_fields_example_3
+
+    with pytest.raises(AttributeError) as excinfo:
+        list_view.get_list_items([article])
+
+    message = "'Article' object has no attribute 'virtual_field'"
+    assert str(excinfo.value) == message

--- a/tests/test_virtual_fields.py
+++ b/tests/test_virtual_fields.py
@@ -15,7 +15,6 @@ def virtual_fields_example_1():
     return TestListView()
 
 
-@pytest.mark.django_db
 def test_virtual_fields_example_1(article, virtual_fields_example_1):
     list_view = virtual_fields_example_1
 
@@ -40,7 +39,6 @@ def virtual_fields_example_2():
     return TestListView()
 
 
-@pytest.mark.django_db
 def test_virtual_fields_example_2(article, virtual_fields_example_2):
     list_view = virtual_fields_example_2
     res = list_view.get_list_items([article])
@@ -63,7 +61,6 @@ def virtual_fields_example_3():
     return TestListView()
 
 
-@pytest.mark.django_db
 def test_virtual_fields_example_3(article, virtual_fields_example_3):
     list_view = virtual_fields_example_3
 

--- a/tests/test_virtual_fields.py
+++ b/tests/test_virtual_fields.py
@@ -1,0 +1,72 @@
+import pytest
+
+from arctic.generics import ListView
+from .conftest import article, request
+
+
+@pytest.fixture
+def virtual_fields_example_1():
+    class TestListView(ListView):
+        paginate_by = 2
+        fields = ['title', 'description', 'published', 'content_type']
+        permission_required = "articles_view"
+        queryset = article()
+
+    return TestListView()
+
+
+@pytest.mark.django_db
+def test_virtual_fields_example_1(virtual_fields_example_1):
+    with pytest.raises(AttributeError):
+        self = virtual_fields_example_1
+        self.request = request('/articles/')
+        objects = self.get_object_list()
+        self.get_list_items([objects])
+
+
+@pytest.fixture
+def virtual_fields_example_2():
+    class TestListView(ListView):
+        paginate_by = 2
+        fields = ['title', 'description', 'published', 'virtual_field']
+        permission_required = "articles_view"
+        queryset = article()
+
+        def get_field_virtual_field(self, row):
+            return 'Virtual Field: ' + row.title
+
+    return TestListView()
+
+
+@pytest.mark.django_db
+def test_virtual_fields_example_2(virtual_fields_example_2):
+    self = virtual_fields_example_2
+    self.request = request('/articles/')
+    objects = self.get_object_list()
+    res = self.get_list_items([objects])
+
+    assert res[0][0] is None
+    assert res[0][1] == 'title1'
+    assert res[0][2] == 'description1'
+    assert res[0][3] == 'published1'
+    assert res[0][4] == 'Virtual Field: title1'
+
+
+@pytest.fixture
+def virtual_fields_example_3():
+    class TestListView(ListView):
+        paginate_by = 2
+        fields = ['title', 'description', 'published', 'virtual_field']
+        permission_required = "articles_view"
+        queryset = article()
+
+    return TestListView()
+
+
+@pytest.mark.django_db
+def test_virtual_fields_example_3(virtual_fields_example_3):
+    with pytest.raises(AttributeError):
+        self = virtual_fields_example_3
+        self.request = request('/articles/')
+        objects = self.get_object_list()
+        self.get_list_items([objects])


### PR DESCRIPTION
Fixed colliding attribute names for virtual_fields. When you create
a virtual field, you need to prefix it now with "get_field_"

Also added some tests to make future development easier.