### PR TITLE
Modify template to keep all tool links in single dropdown

### DIFF
--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -210,6 +210,7 @@ class ListView(View, base.ListView):
     action_links = []  # "Action" links on item level. For example "Edit"
     field_links = {}
     field_classes = {}
+    tool_links_icon = 'fa-wrench'
     tool_links = []   # Global links. For Example "Add object"
     prefix = ''  # Prefix for embedding multiple list views in detail view
 
@@ -414,6 +415,9 @@ class ListView(View, base.ListView):
                                            'icon': icon})
             return allowed_tool_links
 
+    def get_tool_links_icon(self):
+        return self.tool_links_icon
+
     def get_prefix(self):
         return self.prefix + '-' if self.prefix else ''
 
@@ -475,6 +479,7 @@ class ListView(View, base.ListView):
         context['list_items'] = self.get_list_items(context['object_list'])
         context['action_links'] = self.get_action_links()
         context['tool_links'] = self.get_tool_links()
+        context['tool_links_icon'] = self.get_tool_links_icon()
         if self.filter_fields or self.search_fields:
             context['has_filter'] = True
             context['filter'] = self.filterset

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -17,18 +17,18 @@
         {% endif %}
         {% if tool_links %}
             <div class="columns {% if has_filter %}shrink{% endif %}">
-                {% for link in tool_links %}
-                    {% if tool_links|length > 1 or not tool_links.0.icon %}
-                        <button class="button secondary float-right" type="button" data-toggle="tool-links"><i class="fa fa-wrench"></i></button>
+                {% if tool_links|length > 1 %}
+                    <button class="button secondary float-right" type="button" data-toggle="tool-links"><i class="fa fa-wrench"></i></button>
                         <div class="dropdown-pane bottom" id="tool-links" data-dropdown data-close-on-click="true">
                             <ul>
-                                <li><a href="{% url link.url %}">{{ link.label }}</a></li>
+                                {% for link in tool_links %}
+                                    <li><a href="{% url link.url %}">{{ link.label }}</a></li>
+                                {% endfor %}
                             </ul>
                         </div>
-                    {% else %}
-                        <a class="button secondary" title="{{ link.label }}" href="{% url link.url %}"><i class="fa {{ link.icon }}"></i></a>
-                    {% endif %}
-                {% endfor %}
+                {% else %}
+                    <a class="button secondary" title="{{ link.0.label }}" href="{% url link.0.url %}"><i class="fa {% if link.0.icon %}{{ link.0.icon }}{% else %}fa-wrench{% endif %}"></i></a>
+                {% endif %}
             </div>
         {% endif %}
     </div>

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -18,7 +18,7 @@
         {% if tool_links %}
             <div class="columns {% if has_filter %}shrink{% endif %}">
                 {% if tool_links|length > 1 %}
-                    <button class="button secondary float-right" type="button" data-toggle="tool-links"><i class="fa fa-wrench"></i></button>
+                    <button class="button secondary float-right" type="button" data-toggle="tool-links"><i class="fa {{ tool_links_icon }}"></i></button>
                         <div class="dropdown-pane bottom" id="tool-links" data-dropdown data-close-on-click="true">
                             <ul>
                                 {% for link in tool_links %}
@@ -27,7 +27,7 @@
                             </ul>
                         </div>
                 {% else %}
-                    <a class="button secondary" title="{{ link.0.label }}" href="{% url link.0.url %}"><i class="fa {% if link.0.icon %}{{ link.0.icon }}{% else %}fa-wrench{% endif %}"></i></a>
+                    <a class="button secondary" title="{{ link.0.label }}" href="{% url link.0.url %}"><i class="fa {% if link.0.icon %}{{ link.0.icon }}{% else %}{{ tool_links_icon }}{% endif %}"></i></a>
                 {% endif %}
             </div>
         {% endif %}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -218,7 +218,7 @@ can transform the field data into a graphic representation.
 
 list of links with the format `('name', 'url')`, not connected to the table data.
 
-### tool_links_icon
+### `tool_links_icon`
 
 default is fa-wrench. an icon displayed for the dropdown of multiple tool links or, if only one tool link set, it would be use as default icon.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -218,6 +218,9 @@ can transform the field data into a graphic representation.
 
 list of links with the format `('name', 'url')`, not connected to the table data.
 
+### tool_links_icon
+
+default is fa-wrench. an icon displayed for the dropdown of multiple tool links or, if only one tool link set, it would be use as default icon.
 
 ## FormView
 


### PR DESCRIPTION
Fixes #113 

Currently, if I have multiple tool links, e.g.:
```python
tool_links = [
        ('Create admin', 'adminpanel:add_staff_user'),
        ('Create advertiser', 'adminpanel:add_user')
    ]
```
in the template it displayed as two duplicated items:
![arctic_bug_printscreen](https://cloud.githubusercontent.com/assets/3986031/19802491/a176a420-9d0c-11e6-8b7a-2838d025a272.png)

The idea behind this PR:
1. put all links in one dropdown
2. it would be nice to allow user to have configurable dropdown icon

At the end, previous screen would look like:
![arctic-dropdown-fix](https://cloud.githubusercontent.com/assets/3986031/19802578/10acc360-9d0d-11e6-8006-908879693784.png)

The code for screenshot above is:
```python
tool_links_icon = 'fa-user-plus'
tool_links = [
    ('Create admin', 'adminpanel:add_staff_user'),
    ('Create advertiser', 'adminpanel:add_user')
]
```

If tool_links_icon is not set `fa-wrench` will be used instead