### PR TITLE
Fix processing single object in tools links

### DIFF
--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -27,7 +27,7 @@
                             </ul>
                         </div>
                 {% else %}
-                    <a class="button secondary" title="{{ link.0.label }}" href="{% url link.0.url %}"><i class="fa {% if link.0.icon %}{{ link.0.icon }}{% else %}{{ tool_links_icon }}{% endif %}"></i></a>
+                    <a class="button secondary" title="{{ tool_links.0.label }}" href="{% url tool_links.0.url %}"><i class="fa {% if tool_links.0.icon %}{{ tool_links.0.icon }}{% else %}{{ tool_links_icon }}{% endif %}"></i></a>
                 {% endif %}
             </div>
         {% endif %}


### PR DESCRIPTION
In case of one link in `tool_links` in ListView tool links items has been access in wrong way which caused NoReverseMatch error. 

This PR fixes this issue.