### PR TITLE
#124 Daterangeinput fields in inline forms are not enriched with a JS date picker.

### DIFF
--- a/arctic/templates/arctic/partials/form_fields_inline.html
+++ b/arctic/templates/arctic/partials/form_fields_inline.html
@@ -15,7 +15,7 @@
                 {% render_field field placeholder="Search.." %}
             {% elif field|widget_type == 'daterangeinput' %}
                 <div class="field__date">
-                    {% render_field field class+='date-picker' placeholder="Date.." %}
+                    {% render_field field class+='js-datepicker' placeholder="Date.." %}
                 </div>
             {% elif field|widget_type == 'select' and not disable_chosen %}
                 {% render_field field class+='js-selectize' data-placeholder=field.label %}


### PR DESCRIPTION
Daterangeinput fields in inline forms have 'date-picker' as class and are not enriched with a JS date picker. Inputs with class 'js-datepicker' are enriched.