### PR TITLE
Make media assets gathering more flexible

### DIFF
--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -432,3 +432,24 @@ class RoleAuthentication(object):
             except AttributeError:
                 pass
         return result
+
+
+class FormMediaMixin(object):
+    """
+    Gathers media assets defined in forms
+    """
+
+    @property
+    def media(self):
+        # Why not simply call super? Just
+        # to have custom media defined at the bottom,
+        # since order matters here.
+        media = self._get_view_media()
+        media += self._get_form_media()
+        media += self.get_media_assets()
+
+        return media
+
+    def _get_form_media(self):
+        form = self.get_form()
+        return getattr(form, 'media', None)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -116,7 +116,7 @@ Can be `True` or `False`, default is `True`.
 ### `Media`
 
 optional inner class indicating extra media assets to be included. If View is instance of FormView, 
-or CreateView/UpdateView generics all assets defined in form the used in the view will be also included. 
+or CreateView/UpdateView generics all assets defined in form used in the view will be also included. 
 
 Example:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -115,8 +115,8 @@ Can be `True` or `False`, default is `True`.
 
 ### `Media`
 
-optional inner class indicating extra media assets to be included, if the View
-has a form, all the form assets will be also included.
+optional inner class indicating extra media assets to be included. If View is instance of FormView, 
+or CreateView/UpdateView generics all assets defined in form the used in the view will be also included. 
 
 Example:
 
@@ -130,6 +130,10 @@ Example:
             js = ('extra.js', 'another.js')
 
 For more information on the Media class usage check the [Django Form Assets documentation](https://docs.djangoproject.com/en/dev/topics/forms/media/)
+
+### `get_media_assets`
+adds media assets dynamically to view. Does not overrides media from `Media` class but allows to set additional assets 
+ on the fly.
 
 **Methods**
 

--- a/tests/test_generics/test_media_assets.py
+++ b/tests/test_generics/test_media_assets.py
@@ -1,8 +1,9 @@
 import pytest
 
 from django.forms import Form
+from django.forms.widgets import Media
 
-from arctic.generics import View
+from arctic.generics import View, FormView
 
 
 class FormWithAssets(Form):
@@ -11,6 +12,10 @@ class FormWithAssets(Form):
             'all': ('form-common.css', 'view-common.css')
         }
         js = ('form1-1.js', 'form-common.js')
+
+
+class FormWithOutAssets(Form):
+    pass
 
 
 class AnotherFormWithAssets(Form):
@@ -29,6 +34,45 @@ class ViewWithAssets(View):
         js = ('view.js',)
 
 
+class ViewWithForm(FormView, View):
+    form_class = FormWithAssets
+
+
+class FormViewWithOutFormAssets(FormView, View):
+    form_class = FormWithOutAssets
+
+    class Media:
+        css = {
+            'all': ('view.css', 'view-common.css')
+        }
+        js = ('view.js',)
+
+
+class FormViewWithAssets(FormView, View):
+    form_class = FormWithAssets
+
+    class Media:
+        css = {
+            'all': ('view.css', 'view-common.css')
+        }
+        js = ('view.js',)
+
+
+class FormViewWithAssetsAndExtraAssets(FormView, View):
+    form_class = FormWithAssets
+
+    class Media:
+        css = {
+            'all': ('view.css', 'view-common.css')
+        }
+        js = ('view.js',)
+
+    def get_media_assets(self):
+        media = Media()
+        media.add_js(['extra.js'])
+        return media
+
+
 class ViewWithAssetsAndForms(ViewWithAssets):
     form1 = FormWithAssets
     form2 = AnotherFormWithAssets
@@ -40,7 +84,7 @@ class TestViewAssets(object):
     Test media assets in views, including eventual form assets.
     """
 
-    def test_view_with_assets(self):
+    def test_regular_view_with_assets(self):
         view = ViewWithAssets()
         response = """<link href="/static/view.css" type="text/css" media="all" rel="stylesheet" />
 <link href="/static/view-common.css" type="text/css" media="all" rel="stylesheet" />
@@ -52,12 +96,55 @@ class TestViewAssets(object):
         view = ViewWithAssetsAndForms()
         response = """<link href="/static/view.css" type="text/css" media="all" rel="stylesheet" />
 <link href="/static/view-common.css" type="text/css" media="all" rel="stylesheet" />
+<script type="text/javascript" src="/static/view.js"></script>"""  # noqa
+
+        assert str(view.media) == response
+
+    def test_form_view_with_form(self, rf):
+        view = ViewWithForm()
+        request = rf.get('/')
+        view.request = request
+        response = """<link href="/static/form-common.css" type="text/css" media="all" rel="stylesheet" />
+<link href="/static/view-common.css" type="text/css" media="all" rel="stylesheet" />
+<script type="text/javascript" src="/static/form1-1.js"></script>
+<script type="text/javascript" src="/static/form-common.js"></script>"""  # noqa
+
+        assert str(view.media) == response
+
+    def test_form_view_with_assets_and_form(self, rf):
+        view = FormViewWithAssets()
+        request = rf.get('/')
+        view.request = request
+        response = """<link href="/static/view.css" type="text/css" media="all" rel="stylesheet" />
+<link href="/static/view-common.css" type="text/css" media="all" rel="stylesheet" />
 <link href="/static/form-common.css" type="text/css" media="all" rel="stylesheet" />
-<link href="/static/form2.css" type="text/css" media="all" rel="stylesheet" />
+<script type="text/javascript" src="/static/view.js"></script>
+<script type="text/javascript" src="/static/form1-1.js"></script>
+<script type="text/javascript" src="/static/form-common.js"></script>"""  # noqa
+
+        assert str(view.media) == response
+
+    def test_form_view_with_assets_and_form_and_extra_assets(self, rf):
+        view = FormViewWithAssetsAndExtraAssets()
+        request = rf.get('/')
+        view.request = request
+        response = """<link href="/static/view.css" type="text/css" media="all" rel="stylesheet" />
+<link href="/static/view-common.css" type="text/css" media="all" rel="stylesheet" />
+<link href="/static/form-common.css" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/static/view.js"></script>
 <script type="text/javascript" src="/static/form1-1.js"></script>
 <script type="text/javascript" src="/static/form-common.js"></script>
-<script type="text/javascript" src="/static/form2-1.js"></script>"""  # noqa
+<script type="text/javascript" src="/static/extra.js"></script>"""  # noqa
+
+        assert str(view.media) == response
+
+    def test_form_view_without_form_assets(self, rf):
+        view = FormViewWithOutFormAssets()
+        request = rf.get('/')
+        view.request = request
+        response = """<link href="/static/view.css" type="text/css" media="all" rel="stylesheet" />
+<link href="/static/view-common.css" type="text/css" media="all" rel="stylesheet" />
+<script type="text/javascript" src="/static/view.js"></script>"""  # noqa
 
         assert str(view.media) == response
 


### PR DESCRIPTION
Extends great work that have been done in scope of https://github.com/sanoma/django-arctic/issues/195

Initially, we faced the problem with current approach for gathering media from different parts of code: our form failed because no form kwargs has been passed. During investigation, I came up with idea that looks for me very Django-ish :) 
@mmarcos  could you please take a look and, if you like the way I propose, I will extend the code with tests, docs and examples. 

UPD: there are tests broken. I think it is **ok** because now there are checks for any forms in all views. I don't think we need to look through all attributes to get forms. It makes sense for FormViews and its children, but in this case, the most proper way is `get_form` method.