### PR TITLE
Tiny filters fix

### DIFF
--- a/arctic/filters.py
+++ b/arctic/filters.py
@@ -68,7 +68,7 @@ class FilterSet(django_filters.FilterSet):
             elif isinstance(self.filters[filter_name],
                             django_filters.ChoiceFilter):
                 choices = (('', self.filters[filter_name].label),) + \
-                    self.filters[filter_name].extra['choices']
+                    tuple(self.filters[filter_name].extra['choices'])
                 self.filters[filter_name].extra.update(
                     {'choices': choices}
                 )


### PR DESCRIPTION
I've got an exception `TypeError: can only concatenate list (not "tuple") to list` while creating filter fields. 
The interesting thing that I use tuples everywhere for choices definition, however somewhere it was eventually converted to lists. 
Using lists in such situation is not best practice, but I think it still worth to add minor improvement to existing code.