### PR TITLE
Remove print

### DIFF
--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -485,8 +485,6 @@ class ListView(View, base.ListView):
                 row.append({'type': 'actions', 'actions': actions})
                 self.has_action_links = True
             items.append(row)
-
-            print(items)
         return items
 
     def get_field_value(self, field_name, obj):


### PR DESCRIPTION
Remove unnecessary `print`. 
It causes weird issue on the prod, btw :) (looks like it can't access stdout and throw an error)

Is it possible to redeploy 0.9.7 with this fix?





