### PR TITLE
Remove float_label_hack

### DIFF
--- a/arctic/templates/arctic/partials/form_field_parts/form_field_float.html
+++ b/arctic/templates/arctic/partials/form_field_parts/form_field_float.html
@@ -6,7 +6,7 @@
     </label>
 {% else %}
     <div class="form-group">
-        {{ field|float_label_hack }}
+        {{ field }}
         <label for="{{ field.auto_id }}">
             {% include 'arctic/partials/form_field_parts/field_label.html' %}
         </label>

--- a/arctic/templatetags/arctic_tags.py
+++ b/arctic/templatetags/arctic_tags.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, unicode_literals)
 
-import copy
 from collections import OrderedDict
 
 from django import template

--- a/arctic/templatetags/arctic_tags.py
+++ b/arctic/templatetags/arctic_tags.py
@@ -228,10 +228,3 @@ def get_item(dictionary, key):
 @register.filter()
 def get_attr(obj, item, default=None):
     return getattr(obj, item, default)
-
-
-@register.filter
-def float_label_hack(obj):
-    new_obj = copy.deepcopy(obj)
-    new_obj.field.required = True
-    return new_obj


### PR DESCRIPTION
Seems redundant to me. It also prevents creating optional filters as the required flag is hardcoded.