### PR TITLE
feature/263-fixed

### DIFF
--- a/arctic/templates/arctic/partials/form_validation.html
+++ b/arctic/templates/arctic/partials/form_validation.html
@@ -9,15 +9,15 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
                 {% trans "Oops! We found some errors. Please check the error messages below and try again." %}
+                <hr>
+                {% if form.non_field_errors %}
+                    {% for error in form.non_field_errors %}
+                        <p class="mb-0">
+                            {{ error }}
+                        </p>
+                    {% endfor %}
+                {% endif %}
             </div>
         </div>
     </div>
-{% endif %}
-
-
-{% if form.non_field_errors %}
-    {% for error in form.non_field_errors %}
-        {# todo #}
-        <p>{{ error }}</p>
-    {% endfor %}
 {% endif %}


### PR DESCRIPTION
*form_validation mark up to embed non field errors into alert block
Problem described in [issue-263](https://github.com/sanoma/django-arctic/issues/263). 
After fix `form_validation.html` include will render `form.non_field_errors` in following way:

![non_field_errors](https://user-images.githubusercontent.com/6746231/36496187-33b59dec-1740-11e8-8186-ce732231c3c5.png)
