### PR TITLE
Bugfix formaction dict class update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Always reference the ticket number at the end of the issue description.
 
+## Pending
+
+### Fixed
+
+- get_actions: formaction dictionary was updated directly as class attribute
 
 ## 1.3.1 (2018-07-03)
 

--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -188,7 +188,7 @@ class FormMixin(ModalMixin):
                         if action[2].get('style'):
                             allowed_action['custom_style'] = True
                         if action[2].get('form_action'):
-                            action[2]['form_action'] = self.in_modal(
+                            allowed_action['form_action'] = self.in_modal(
                                 reverse_url(action[2]['form_action'], obj))
                         allowed_action.update(action[2])
 


### PR DESCRIPTION
# Description

The actions property of a View can contain a dictionary with a formaction. In Python, if you set a dictionary as an attribute to a class, and you update its value, the class dict is updated, not only the instance itself. Changed the code to no longer update the actions directly.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
