### PR TITLE
fixed dict update in get_actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Always reference the ticket number at the end of the issue description.
 ### Fixed
 
 - get_actions: formaction dictionary was updated directly as class attribute
+- get_actions: update dict in correct order
 
 ## 1.3.1 (2018-07-03)
 

--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -185,12 +185,12 @@ class FormMixin(ModalMixin):
                     if action[2] == 'left':
                         allowed_action['position'] = 'left'
                     elif type(action[2]) is dict:
+                        allowed_action.update(action[2])
                         if action[2].get('style'):
                             allowed_action['custom_style'] = True
                         if action[2].get('form_action'):
                             allowed_action['form_action'] = self.in_modal(
                                 reverse_url(action[2]['form_action'], obj))
-                        allowed_action.update(action[2])
 
                 if action[1] == 'submit':
                     last_submit_index = len(allowed_actions)


### PR DESCRIPTION
# Description

The allowed action dict was updated in the wrong order, which made the form_action being reset after resolving the url to the url name.

## Type of change
- Bug fix (non-breaking change which fixes an issue)