### PR TITLE
added ability to specify not required parameter for action link. Fixe…

### DIFF
--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -681,6 +681,7 @@ class ListMixin(ModalMixin):
                             )
                         ),
                         "modal": self.get_modal_link(field_action["url"], obj),
+                        'attributes': field_action["attributes"]
                     }
                 )
             return actions
@@ -710,9 +711,19 @@ class ListMixin(ModalMixin):
 
         return self._allowed_action_links
 
+    def _get_custom_attributes(self, action_link):
+        attributes = None
+        if len(action_link) == 4:
+            attributes = action_link[3]
+        # take into account that 3 parameter can be string icon class
+        elif len(action_link) == 3 and isinstance(action_link[2], dict):
+            attributes = action_link[2]
+        return attributes
+
     def _build_action_link(self, action_link):
-        icon = action_link[2] if len(action_link) == 3 else None
-        return {"label": action_link[0], "url": action_link[1], "icon": icon}
+        icon = action_link[2] if len(action_link) >= 3 and isinstance(action_link[2], str) else None
+        return {"label": action_link[0], "url": action_link[1],
+                "icon": icon, "attributes": self._get_custom_attributes(action_link)}
 
     def get_tool_links(self):
         if not self.tool_links:

--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -711,19 +711,17 @@ class ListMixin(ModalMixin):
 
         return self._allowed_action_links
 
-    def _get_custom_attributes(self, action_link):
-        attributes = None
-        if len(action_link) == 4:
-            attributes = action_link[3]
-        # take into account that 3 parameter can be string icon class
-        elif len(action_link) == 3 and isinstance(action_link[2], dict):
-            attributes = action_link[2]
-        return attributes
-
     def _build_action_link(self, action_link):
-        icon = action_link[2] if len(action_link) >= 3 and isinstance(action_link[2], str) else None
+        icon, attributes = None, None
+        if len(action_link) == 3:
+            # icon can be 3-rd arg of link or specified inside inside dict with same index
+            if isinstance(action_link[2], str):
+                icon = action_link[2]
+            elif isinstance(action_link[2], dict):
+                icon = action_link[2].get('icon_class', None)
+                attributes = action_link[2].get('attributes', None)
         return {"label": action_link[0], "url": action_link[1],
-                "icon": icon, "attributes": self._get_custom_attributes(action_link)}
+                "icon": icon, "attributes": attributes}
 
     def get_tool_links(self):
         if not self.tool_links:

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -139,8 +139,13 @@
                                             {% block list_actions %}
                                             <div class="list-actions">
                                                 {% for action in row.actions %}
-                                                    <a href="{{ action.url }}" class="action-{{ action.label }} btn btn-secondary btn-sm show-on-hover" title="{{ link.label|capfirst }}"
+                                                    <a href="{{ action.url }}" class="action-{{ action.label }} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
                                                     {% include 'arctic/partials/modal_attributes.html' with modal=action.modal %}
+                                                    {% if action.attributes %}
+                                                        {% for attr_name, attr_value in action.attributes.items %}
+                                                            {{ attr_name }}="{{ attr_value }}"
+                                                        {% endfor %}
+                                                    {% endif %}
                                                     >
                                                     {% if action.icon %}
                                                         <i class="fa {{ action.icon }} fa-lg"></i>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -316,6 +316,8 @@ standard notation by prepending a minus to the field, for example `-name`.
 optional list of `('name', 'base_url', 'optional icon class')` links, that
 appear on the last column of the table and can apply a certain action, such
 as delete.
+In case if some custom attributes required, they can be specified as last argument in form of dict.
+`('name', 'base_url', 'optional icon class', {'custom_attr_name': 'custom_attr_value'})`
 
 ### `get_field_actions(row)`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -316,8 +316,9 @@ standard notation by prepending a minus to the field, for example `-name`.
 optional list of `('name', 'base_url', 'optional icon class')` links, that
 appear on the last column of the table and can apply a certain action, such
 as delete.
-In case if some custom attributes required, they can be specified as last argument in form of dict.
-`('name', 'base_url', 'optional icon class', {'custom_attr_name': 'custom_attr_value'})`
+In case if some custom attributes required, they can be specified as last argument in form of dict. In this case
+optional icon class can be provided as part of that argument dict
+`('name', 'base_url', 'optional icon class', {'icon_class': 'fa', 'attributes': {'custom_attr_name': 'custom_attr_value'}})`
 
 ### `get_field_actions(row)`
 


### PR DESCRIPTION
`action_link` changes and fixes.

# Description
Fixed action link `title` attribute that was broken.
Added ability to specify additional custom attributes for action link.
Updated documentation.

Example case:
Add attribute 
```
target="_blank"
```
to open link in new tab.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
