### PR TITLE
Added ability to select custom class on action links

### DIFF
--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -713,7 +713,7 @@ class ListMixin(ModalMixin):
         return self._allowed_action_links
 
     def _build_action_link(self, action_link):
-        icon,  attributes = None, None
+        icon, attributes = None, None
         attributes_class = "action-{}".format(action_link[0])
         if len(action_link) == 3:
             # icon can be 3-rd arg of link or specified inside inside dict with same index

--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -675,6 +675,7 @@ class ListMixin(ModalMixin):
                     {
                         "label": field_action["label"],
                         "icon": field_action["icon"],
+                        "class": field_action['class'],
                         "url": self.in_modal(
                             reverse_url(
                                 field_action["url"], obj, self.primary_key
@@ -712,15 +713,16 @@ class ListMixin(ModalMixin):
         return self._allowed_action_links
 
     def _build_action_link(self, action_link):
-        icon, attributes = None, None
+        icon, action_class, attributes = None, None, None
         if len(action_link) == 3:
             # icon can be 3-rd arg of link or specified inside inside dict with same index
             if isinstance(action_link[2], str):
                 icon = action_link[2]
             elif isinstance(action_link[2], dict):
                 icon = action_link[2].get('icon_class', None)
+                action_class = action_link[2].get('action_class', None)
                 attributes = action_link[2].get('attributes', None)
-        return {"label": action_link[0], "url": action_link[1],
+        return {"label": action_link[0], "url": action_link[1], 'class': action_class,
                 "icon": icon, "attributes": attributes}
 
     def get_tool_links(self):

--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -713,16 +713,18 @@ class ListMixin(ModalMixin):
         return self._allowed_action_links
 
     def _build_action_link(self, action_link):
-        icon, action_class, attributes = None, None, None
+        icon,  attributes = None, None
+        attributes_class = "action-{}".format(action_link[0])
         if len(action_link) == 3:
             # icon can be 3-rd arg of link or specified inside inside dict with same index
             if isinstance(action_link[2], str):
                 icon = action_link[2]
             elif isinstance(action_link[2], dict):
                 icon = action_link[2].get('icon_class', None)
-                action_class = action_link[2].get('action_class', None)
                 attributes = action_link[2].get('attributes', None)
-        return {"label": action_link[0], "url": action_link[1], 'class': action_class,
+                if attributes and attributes.get('class', None) and isinstance(attributes.get('class', None), list):
+                    attributes_class = " ".join(attributes.get('class'))
+        return {"label": action_link[0], "url": action_link[1], 'class': attributes_class,
                 "icon": icon, "attributes": attributes}
 
     def get_tool_links(self):

--- a/arctic/mixins.py
+++ b/arctic/mixins.py
@@ -714,7 +714,7 @@ class ListMixin(ModalMixin):
 
     def _build_action_link(self, action_link):
         icon, attributes = None, None
-        attributes_class = "action-{}".format(action_link[0])
+        attributes_class = generate_id('action', action_link[0])
         if len(action_link) == 3:
             # icon can be 3-rd arg of link or specified inside inside dict with same index
             if isinstance(action_link[2], str):

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -139,7 +139,7 @@
                                             {% block list_actions %}
                                             <div class="list-actions">
                                                 {% for action in row.actions %}
-                                                    <a href="{{ action.url }}" class="action-{{ action.label }} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
+                                                    <a href="{{ action.url }}" class="action-{% if action.class %}{{ action.class }}{% else %}{{ action.label }}{% endif %} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
                                                     {% include 'arctic/partials/modal_attributes.html' with modal=action.modal %}
                                                     {% if action.attributes %}
                                                         {% for attr_name, attr_value in action.attributes.items %}

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -139,7 +139,7 @@
                                             {% block list_actions %}
                                             <div class="list-actions">
                                                 {% for action in row.actions %}
-                                                    <a href="{{ action.url }}" class="action-{% if action.class %}{{ action.class }}{% else %}{{ action.label }}{% endif %} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
+                                                    <a href="{{ action.class }} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
                                                     {% include 'arctic/partials/modal_attributes.html' with modal=action.modal %}
                                                     {% if action.attributes %}
                                                         {% for attr_name, attr_value in action.attributes.items %}

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -139,7 +139,7 @@
                                             {% block list_actions %}
                                             <div class="list-actions">
                                                 {% for action in row.actions %}
-                                                    <a href="{{ action.class }} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
+                                                    <a href="{{ action.url }}" class="{{ action.class }} btn btn-secondary btn-sm show-on-hover" title="{{ action.label|capfirst }}"
                                                     {% include 'arctic/partials/modal_attributes.html' with modal=action.modal %}
                                                     {% if action.attributes %}
                                                         {% for attr_name, attr_value in action.attributes.items %}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -318,7 +318,7 @@ appear on the last column of the table and can apply a certain action, such
 as delete.
 In case if some custom attributes required, they can be specified as last argument in form of dict. In this case
 optional icon class can be provided as part of that argument dict
-`('name', 'base_url', 'optional icon class', {'icon_class': 'fa', 'attributes': {'custom_attr_name': 'custom_attr_value'}})`
+`('name', 'base_url', 'optional icon class', {'icon_class': 'fa', 'action_class': 'name', 'attributes': {'custom_attr_name': 'custom_attr_value'}})`
 
 ### `get_field_actions(row)`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -317,8 +317,9 @@ optional list of `('name', 'base_url', 'optional icon class')` links, that
 appear on the last column of the table and can apply a certain action, such
 as delete.
 In case if some custom attributes required, they can be specified as last argument in form of dict. In this case
-optional icon class can be provided as part of that argument dict
-`('name', 'base_url', 'optional icon class', {'icon_class': 'fa', 'action_class': 'name', 'attributes': {'custom_attr_name': 'custom_attr_value'}})`
+optional icon class can be provided as part of that argument dict. 
+Classes for action link can be specified as a list.
+`('name', 'base_url', 'optional icon class', {'icon_class': 'fa', 'attributes': {'class': ['class0', 'class1'], 'custom_attr_name': 'custom_attr_value'}})`
 
 ### `get_field_actions(row)`
 


### PR DESCRIPTION
Added ability to select custom class on action links. It is very helpful if, for example, translations are used
- New feature (non-breaking change which adds functionality)