### PR TITLE
Feature/login view logout action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Always reference the ticket number at the end of the issue description.
 
+## Pending
+
+### Fixed
+
+- Do not logout logged-in users which visit the login view, but redirect them to home
 
 ## 1.3.5 (2018-12-21)
 

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -910,7 +910,8 @@ class LoginView(FormView):
         return context
 
     def get(self, request, *args, **kwargs):
-        logout(request)
+        if request.user.is_authenticated:
+            return redirect("/")
         return super(LoginView, self).get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -910,7 +910,11 @@ class LoginView(FormView):
         return context
 
     def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
+        # If the logout url is the login url, log the user out of the system
+        if settings.LOGOUT_URL == settings.LOGIN_URL:
+            logout(request)
+        # Else redirect a logged in user to the homepage
+        elif request.user.is_authenticated:
             return redirect("/")
         return super(LoginView, self).get(request, *args, **kwargs)
 

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -6,7 +6,7 @@ import json
 import extra_views
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth import authenticate, login
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.exceptions import (
     FieldDoesNotExist,

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -6,7 +6,7 @@ import json
 import extra_views
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import authenticate, login
+from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.exceptions import (
     FieldDoesNotExist,
@@ -933,3 +933,9 @@ class LoginView(FormView):
         return render(
             request, self.template_name, self.get_context_data(**kwargs)
         )
+
+
+class LogoutView(View):
+    def dispatch(self, request, *args, **kwargs):
+        logout(request)
+        return redirect(settings.LOGIN_URL)

--- a/arctic/project_template/config/settings.py
+++ b/arctic/project_template/config/settings.py
@@ -112,7 +112,8 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 
-LOGIN_URL = LOGOUT_URL = "login"
+LOGIN_URL = "login"
+LOGOUT_URL = "logout"
 
 # Arctic configuration
 ARCTIC_SITE_NAME = "{{ project_name }}'s Arctic website"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -122,6 +122,10 @@ Being a pure Django settings, LOGIN_URL and LOGOUT_URL used in Arctic to display
 login and logout links. Both items supposed to be names of URLs. Defaults are 'login'
 and 'logout'. Could be set to `None` if you don't want to use authentication in your app.
 
+If the LOGIN_URL and LOGOUT_URL are the same, the LoginView will automatically logout
+the user when he visits the login page. If they are different, a logged in user will be
+redirected to the homepage of the CMS and not be logged out.
+
 # Generic Class Based Views
 
 Arctic provides a number of class based views that add integration with the

--- a/example/config/settings.py
+++ b/example/config/settings.py
@@ -120,7 +120,8 @@ STATIC_URL = "/static/"
 MEDIA_ROOT = location("media")
 MEDIA_URL = "/media/"
 
-LOGIN_URL = LOGOUT_URL = "login"
+LOGIN_URL = "login"
+LOGOUT_URL = "logout"
 
 
 try:

--- a/example/config/urls.py
+++ b/example/config/urls.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 
-from arctic.generics import LoginView
+from arctic.generics import LoginView, LogoutView
 from arctic.views import handler400, handler403, handler404, handler500  # noqa
 
 from countries.views import CountryAPIView, CountryListView
@@ -14,6 +14,7 @@ from dashboard.views import DashboardView
 urlpatterns = [
     url(r"^$", DashboardView.as_view(), name="index"),
     url(r"^login/$", LoginView.as_view(), name="login"),
+    url(r"^logout/$", LogoutView.as_view(), name="logout"),
     url(r"^articles/", include("articles.urls", "articles")),
     url(r"^users/", include("arctic.users.urls", namespace="users")),
     url(r"^countries/$", CountryListView.as_view(), name="countries-list"),


### PR DESCRIPTION
# Description

When a logged in user navigates to the login page (for example via a bookmark), he is logged out immediately. It would be more logical to redirect him to the logged in home. We had issues with CSRF tokens, when editors are editing an article, and open a new tab, login again, and then save in the original article tab. 

## Type of change

- Fix (non breaking change):
