### PR TITLE
set the correct language in the html tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Always reference the ticket number at the end of the issue description.
 ### Fixed
 
 - Do not logout logged-in users which visit the login view, but redirect them to home
+- Set the correct language in the html tag
 
 ## 1.3.5 (2018-12-21)
 

--- a/arctic/templates/arctic/base.html
+++ b/arctic/templates/arctic/base.html
@@ -1,7 +1,7 @@
 {% load i18n staticfiles arctic_tags %}
-
+{% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}">
 
     <head>
         {% include "arctic/partials/head.html" %}


### PR DESCRIPTION
# Description

<html lang="en"> was hardcoded in the base.html template. Now it uses the LANGUAGE_CODE setting from Django to fill in this value.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
