### PR TITLE
#334 BREAKING Fix of response in DeletionMixin after `delete` method is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Always reference the ticket number at the end of the issue description.
 
 ### Fixed
 
-- Fixed response in DeletionMixin after `delete` method is called [#334][334]
+- BREAKING! Fixed response in DeletionMixin after `delete` method is called [#334][334]
 
 [334]: //github.com/sanoma/django-arctic/issues/334
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Always reference the ticket number at the end of the issue description.
 
 
+## pending
+
+### Fixed
+
+- Fixed response in DeletionMixin after `delete` method is called [#334][334]
+
+[334]: //github.com/sanoma/django-arctic/issues/334
+
+
 ## 1.3.6 (2019-01-22)
 
 ### Fixed
@@ -30,7 +39,6 @@ Always reference the ticket number at the end of the issue description.
 
 [324]: //github.com/sanoma/django-arctic/issues/324
 [322]: //github.com/sanoma/django-arctic/issues/322
-## pending:
 
 ## 1.3.5 (2018-12-21)
 

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -873,8 +873,7 @@ class DeleteView(View, base.DeleteView):
 
         if can_delete and self.redirect:
             messages.success(request, self.get_success_message(self.object))
-            self.delete(request, *args, **kwargs)
-            return redirect(self.get_success_url())
+            return self.delete(request, *args, **kwargs)
 
         context = self.get_context_data(
             object=self.object,


### PR DESCRIPTION
# Description

DeletionMixin was creating HttpResponse 2 times and sending last one, for which was not possible to customize `success_url` because at that moment `self.object` is already gone.   
I changed it to return HttpResponse, already created by `delete` method instead of creating one more in `get` method once again. 

**After this fix all overridden `delete` method should be checked and ensured that they return HttpResponses (it was expected that parent method will build at the end), otherwise it will brake those views.** 
 
Fixes #334 

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
