### PR TITLE
#334 NON breaking  Fix of response in DeletionMixin after `delete` method is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Always reference the ticket number at the end of the issue description.
 
 
+## pending
+
+### Fixed
+
+- Fixed response in DeletionMixin after `delete` method is called [#334][334]
+
+[334]: //github.com/sanoma/django-arctic/issues/334
+
+
 ## 1.3.6 (2019-01-22)
 
 ### Fixed
@@ -30,7 +39,6 @@ Always reference the ticket number at the end of the issue description.
 
 [324]: //github.com/sanoma/django-arctic/issues/324
 [322]: //github.com/sanoma/django-arctic/issues/322
-## pending:
 
 ## 1.3.5 (2018-12-21)
 

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -873,7 +873,10 @@ class DeleteView(View, base.DeleteView):
 
         if can_delete and self.redirect:
             messages.success(request, self.get_success_message(self.object))
-            return self.delete(request, *args, **kwargs)
+            self.object = self.get_object()
+            success_url = self.get_success_url()
+            self.delete(request, *args, **kwargs)
+            return redirect(success_url)
 
         context = self.get_context_data(
             object=self.object,
@@ -882,6 +885,13 @@ class DeleteView(View, base.DeleteView):
             protected_objects=protected_objects,
         )
         return self.render_to_response(context)
+
+    def delete(self, request, *args, **kwargs):
+        """
+        Calls the delete() method on the fetched object and then
+        redirects to the success URL.
+        """
+        self.object.delete()
 
     def post(self, request, *args, **kwargs):
         response = super(DeleteView, self).post(request, *args, **kwargs)

--- a/arctic/generics.py
+++ b/arctic/generics.py
@@ -873,8 +873,7 @@ class DeleteView(View, base.DeleteView):
 
         if can_delete and self.redirect:
             messages.success(request, self.get_success_message(self.object))
-            self.delete(request, *args, **kwargs)
-            return redirect(self.get_success_url())
+            return self.delete(request, *args, **kwargs)
 
         context = self.get_context_data(
             object=self.object,


### PR DESCRIPTION
# Description

DeletionMixin was creating HttpResponse 2 times and sending last one, for which was not possible to customize `success_url` because at that moment `self.object` is already gone.   
I moved getting object to `get` method and override default Django's `delete` method to simply it and remove duplicated actions. 

This bug is also fixed with overriding default django staff but with breaking changes here: 
https://github.com/sanoma/django-arctic/pull/337

## Type of change

Delete options that are not relevant:

- Bug fix (non-breaking change which fixes an issue)