### PR TITLE
#344 Disabled options ordering by selectize in all Selectize widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ Always reference the ticket number at the end of the issue description.
 - BREAKING! Fixed response in DeletionMixin after `delete` method is called [#334][334]
 - Added default `select_multiple` attr for `QuickFiltersSelectMultiple` widget [#340][340]
 - Updated Selectize version [#334][334]
+- Disabled options ordering by selectize in all Selectize widgets [#344][344]
 
 [334]: //github.com/sanoma/django-arctic/issues/334
 [340]: //github.com/sanoma/django-arctic/issues/340
 [342]: //github.com/sanoma/django-arctic/issues/342
+[344]: //github.com/sanoma/django-arctic/issues/344
 
 
 ## 1.3.6 (2019-01-22)

--- a/arctic/static/arctic/src/assets/js/components/widgets.js
+++ b/arctic/static/arctic/src/assets/js/components/widgets.js
@@ -57,6 +57,11 @@ $(document).ready(function() {
                 if ($(instance).next().find('.item').length == 0) {
                     $(instance).next().next().removeAttr('style');
                 }
+            },
+            // Selectize reoders search results to find best match.
+            // But we wan't to keep original order by default
+            score: function() {
+              return function() { return 1 };
             }
         });
     });
@@ -83,6 +88,11 @@ $(document).ready(function() {
                     value: input,
                     text: input
                 }
+            },
+            // Selectize reoders search results to find best match.
+            // But we wan't to keep original order by default
+            score: function() {
+              return function() { return 1 };
             }
         });
     });
@@ -119,6 +129,11 @@ $(document).ready(function() {
                     $(instance).next().next().removeAttr('style');
                 }
             },
+            // Selectize reoders search results to find best match.
+            // But we wan't to keep original order by default
+            score: function() {
+              return function() { return 1 };
+            }
         });
     });
 


### PR DESCRIPTION
# Description

This is disabling options ordering by selectize, described in #344 

Fixes #344 

## Type of change

- Bug fix (non-breaking change which fixes an issue)