### PR TITLE
Replace staticfiles tag with static to fix django 2.1 deprecation warning

### DIFF
--- a/arctic/templates/arctic/403.html
+++ b/arctic/templates/arctic/403.html
@@ -1,5 +1,5 @@
 {% extends "arctic/base.html" %}
-{% load i18n staticfiles arctic_tags %}
+{% load i18n static arctic_tags %}
 
 {% block title %}Access forbidden{% endblock %}
 

--- a/arctic/templates/arctic/base.html
+++ b/arctic/templates/arctic/base.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles arctic_tags %}
+{% load i18n static arctic_tags %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}">

--- a/arctic/templates/arctic/base_confirm_delete.html
+++ b/arctic/templates/arctic/base_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends request.is_ajax|yesno:"arctic/base_dialog.html,arctic/base.html" %}
 
 
-{% load i18n arctic_tags staticfiles %}
+{% load i18n arctic_tags static %}
 
 
 {% block body_class %}

--- a/arctic/templates/arctic/base_create_update.html
+++ b/arctic/templates/arctic/base_create_update.html
@@ -1,6 +1,6 @@
 {% extends in_modal|yesno:"arctic/base_modal.html,arctic/base.html" %}
 
-{% load i18n arctic_tags staticfiles %}
+{% load i18n arctic_tags static %}
 
 {% block body_class %}
     {{ block.super }}

--- a/arctic/templates/arctic/base_modal.html
+++ b/arctic/templates/arctic/base_modal.html
@@ -1,5 +1,5 @@
 {% extends "arctic/base.html" %}
-{% load i18n staticfiles arctic_tags %}
+{% load i18n static arctic_tags %}
 
 {% block body_class %}{{ block.super }} arctic-modal{% endblock %}
 

--- a/arctic/templates/arctic/login.html
+++ b/arctic/templates/arctic/login.html
@@ -1,7 +1,7 @@
 {% extends "arctic/base.html" %}
 
 
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 
 {% block title %}

--- a/arctic/templates/arctic/partials/base_data_table.html
+++ b/arctic/templates/arctic/partials/base_data_table.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles arctic_tags arctic_pagination_tags %}
+{% load i18n static arctic_tags arctic_pagination_tags %}
 
 <div class="row">
     {% block tool_links %}

--- a/arctic/templates/arctic/partials/head.html
+++ b/arctic/templates/arctic/partials/head.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles  %}
+{% load i18n static  %}
 
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/arctic/templates/arctic/partials/menu.html
+++ b/arctic/templates/arctic/partials/menu.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles arctic_tags %}
+{% load i18n static arctic_tags %}
 <div class="sidebar__header">
     <a href="{{ index_url }}" class="logo">
         <img src="{% static SITE_LOGO %}" />


### PR DESCRIPTION
# Description

Since 2.1 release Django deprecated statcifiles tag in favour of static. For more information please check [Features deprecated in 2.1](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-deprecated-in-2-1)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
